### PR TITLE
fix: corrigir imports incorretos no arquivo monitoring/route.ts

### DIFF
--- a/src/app/api/admin/monitoring/route.ts
+++ b/src/app/api/admin/monitoring/route.ts
@@ -5,7 +5,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getJuditApiClient } from '@/lib/judit-api-client';
-import { processMonitorQueue, addMonitoringJob, getMonitoringStats } from '@/workers/process-monitor-worker';
+import { processMonitorQueue, addMonitoringJob, getMonitoringStats } from '../../../../workers/process-monitor-worker';
 import { telemetry } from '@/lib/monitoring-telemetry';
 import { ICONS } from '@/lib/icons';
 


### PR DESCRIPTION
- Ajustar path do import do process-monitor-worker para caminho relativo correto
- Resolver erro de build no Vercel

🤖 Generated with [Claude Code](https://claude.ai/code)